### PR TITLE
Add 'LeastMax' Parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,7 @@
             <th colspan="2">Friday</th>
             <th colspan="2">Saturday</th>
             <th rowspan="2">Week Min</th>
+			<th rowspan="2">Least Max</th>
             <th rowspan="2">Week Max</th>
           </tr>
           <tr>

--- a/js/predictions.js
+++ b/js/predictions.js
@@ -595,6 +595,7 @@ function analyze_possibilities(sell_prices) {
       weekMaxes.push(day.max);
     }
     poss.weekMin = Math.min(...weekMins);
+	poss.weekLeastMax = Math.max(...weekMins);
     poss.weekMax = Math.max(...weekMaxes);
   }
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -94,7 +94,7 @@ const calculateOutput = function (data) {
         out_line += `<td class="one">${day.min}</td>`;
       }
     }
-    out_line += `<td class="one">${poss.weekMin}</td><td class="one">${poss.weekMax}</td></tr>`;
+    out_line += `<td class="one">${poss.weekMin}</td><td class="one">${poss.weekLeastMax}</td><td class="one">${poss.weekMax}</td></tr>`;
     output_possibilities += out_line
   }
 


### PR DESCRIPTION
Add additional logic to compute 'LeastMax', which represents the worst case scenario maximum price achievable during the week (assuming everything is sold on the correct day). I think this is more useful than the current weekMin, since most people won't be selling then, but I'm in favor of displaying both.

I think the parameter is definitely in need of a better name, but it will be helpful in determining a realistic range of prices that the turnips can be sold for to maximize profit.