### PR TITLE
feat: Add toggle for filtering results to first ever buy

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <div class="col s12 m5">
       <div class="card-panel z-depth-0">
         <span>
-          To use, enter as much data as you can from <b>your own island</b>. If you bought from Daisy on your own island <b>for the first time this week</b> leave the buy price blank. The tool will figure out all possible patterns and predict the lowest and highest prices for each day.
+          To use, enter as much data as you can from <b>your own island</b>. The tool will figure out all possible patterns and predict the lowest and highest prices for each day.
           <p />
           I couldn't have done this without <a href="https://twitter.com/_Ninji/status/1244818665851289602?s=20">Ninji's work extracting the code</a>
           <p />
@@ -38,11 +38,30 @@
       </div>
     </div>
     <div class="row">
-      <div class="col s2">
+      <div class="col s12">
         <h5>Daisy Mae</h5>
-        <div class="input-field">
-          <label for="buy">Buy price</label>
-          <input type="number" id="buy">
+        <div class="row">
+          <div class="col s2">
+            <div class="input-field">
+              <label for="buy">Buy price</label>
+              <input type="number" id="buy">
+            </div>
+          </div>
+          <div class="col s2">
+            <div class="input-field">
+              <label>
+                <input id="first_buy" type="checkbox" class="filled-in" />
+                <span>First time buyer</span>
+              </label>
+            </div>
+          </div>
+          <div class="col s6">
+            <div class="input-field">
+              <span>
+                Check this box if you bought from Daisy on your own island <b>for the first time ever</b>. If you bought from her on your own island in a previous week, leave this box unchecked.
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/js/predictions.js
+++ b/js/predictions.js
@@ -285,7 +285,7 @@ function* generate_pattern_1_with_peak(given_prices, peak_start) {
     });
   }
   yield {
-    pattern_description: "decreasing, high spike, random lows",
+    pattern_description: "decreasing middle, high spike, random low",
     pattern_number: 1,
     prices: predicted_prices
   };
@@ -351,7 +351,7 @@ function* generate_pattern_2(given_prices) {
     max_rate -= 300;
   }
   yield {
-    pattern_description: "always decreasing",
+    pattern_description: "consistently decreasing",
     pattern_number: 2,
     prices: predicted_prices
   };
@@ -543,26 +543,29 @@ function* generate_pattern_3(given_prices) {
   }
 }
 
-
-function* generate_possibilities(sell_prices) {
-  if (!isNaN(sell_prices[0])) {
+function* generate_possibilities(sell_prices, first_buy) {
+  if (first_buy || isNaN(sell_prices[0])) {
+    for (var buy_price = 90; buy_price <= 110; buy_price++) {
+      sell_prices[0] = sell_prices[1] = buy_price;
+      if (first_buy) {
+        yield* generate_pattern_3(sell_prices);
+      } else {
+        yield* generate_pattern_0(sell_prices);
+        yield* generate_pattern_1(sell_prices);
+        yield* generate_pattern_2(sell_prices);
+        yield* generate_pattern_3(sell_prices);
+      }
+    }
+  } else {
     yield* generate_pattern_0(sell_prices);
     yield* generate_pattern_1(sell_prices);
     yield* generate_pattern_2(sell_prices);
     yield* generate_pattern_3(sell_prices);
-  } else {
-    for (var buy_price = 90; buy_price <= 110; buy_price++) {
-      sell_prices[0] = sell_prices[1] = buy_price;
-      yield* generate_pattern_0(sell_prices);
-      yield* generate_pattern_1(sell_prices);
-      yield* generate_pattern_2(sell_prices);
-      yield* generate_pattern_3(sell_prices);
-    }
   }
 }
 
-function analyze_possibilities(sell_prices) {
-  generated_possibilities = Array.from(generate_possibilities(sell_prices));
+function analyze_possibilities(sell_prices, first_buy) {
+  generated_possibilities = Array.from(generate_possibilities(sell_prices, first_buy));
 
   global_min_max = [];
   for (var day = 0; day < 14; day++) {


### PR DESCRIPTION
This PR introduces a new toggle for limiting results to what is possible in your first ever week of purchasing Turnips. In your first week, your buy price is regenerated on the day after your first purchase, and your pattern is locked to pattern 3 for that week.

When the toggle is enabled, any value entered into the buy price field is ignored, and we only generate the pattern 3 results.

I also renamed the descriptions to match what they are called in Ninji's reverse engineering; I thought it would be best to remain consistent with the source material.

Based on the information provided by Ninji here: 
https://twitter.com/_Ninji/status/1245097287136706561
https://gist.github.com/Treeki/85be14d297c80c8b3c0a76375743325b#file-turnipprices-cpp-L214