### PR TITLE
Readable dynamic length querystrings

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -101,8 +101,17 @@ const getPricesFromQuery = function () {
     const params = new URLSearchParams(window.location.search.substr(1));
     const sell_prices = params.get("prices").split(".").map((x) => parseInt(x, 10));
 
-    if (!Array.isArray(sell_prices) || sell_prices.length !== 14) {
+    if (!Array.isArray(sell_prices)) {
       return null;
+    }
+
+    // Parse the array which is formatted like: [price, M-AM, M-PM, T-AM, T-PM, W-AM, W-PM, Th-AM, Th-PM, F-AM, F-PM, S-AM, S-PM, Su-AM, Su-PM]
+    // due to the format of local storage we need to double up the price at the start of the array.
+    sell_prices.unshift(sell_prices[0]);
+
+    // This allows us to fill out the missing fields at the end of the array
+    for (let i = sell_prices.length; i < 14; i++) {
+      sell_prices.push(0);
     }
 
     window.price_from_query = true;


### PR DESCRIPTION
This adjusts the current querystring load to allow for shorter, more readable querystrings, which will be easier to construct from apps or spreadsheets and easier to visually parse.

Removed the double price at the start of the string that is currently there, and allows us to remove any values that have yet to be populated.

old querystring:
https://turnipprophet.io/?prices=99.99.43.40.35.31.27.0.0.0.0.0.0.0

new query string:
https://turnipprophet.io/?prices=99.43.40.35.31.27

if there are values missing in previous fields it would look like this:
https://turnipprophet.io/?prices=99.43..35.31.27
or
https://turnipprophet.io/?prices=99.43.0.35.31.27

