### PR TITLE
Add a guaranteed future minimum column

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,6 +240,7 @@
                 </div>
               </th>
               <th valign="bottom">Guaranteed Minimum</th>
+			  <th valign="bottom">Guaranteed Future Minimum</th>
               <th valign="bottom">Potential Maximum</th>
             </tr>
           </thead>

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
                 </div>
               </th>
               <th valign="bottom">Guaranteed Minimum</th>
-			  <th valign="bottom">Guaranteed Future Minimum</th>
+              <th valign="bottom">Guaranteed Future Minimum</th>
               <th valign="bottom">Potential Maximum</th>
             </tr>
           </thead>

--- a/js/predictions.js
+++ b/js/predictions.js
@@ -661,8 +661,6 @@ function analyze_possibilities(sell_prices, first_buy, previous_pattern) {
     poss.weekGuaranteedMinimum = Math.max(...weekMins);
     poss.weekMax = Math.max(...weekMaxes);
 	poss.futureMin = Math.max(...futureMins);
-	console.log(poss.futureMins)
-	console.log(poss.futureMin);
   }
 
   generated_possibilities.sort((a, b) => a.weekMax < b.weekMax);

--- a/js/predictions.js
+++ b/js/predictions.js
@@ -660,7 +660,7 @@ function analyze_possibilities(sell_prices, first_buy, previous_pattern) {
     }
     poss.weekGuaranteedMinimum = Math.max(...weekMins);
     poss.weekMax = Math.max(...weekMaxes);
-	poss.futureMin = Math.max(...futureMins);
+    poss.futureMin = Math.max(...futureMins);
   }
 
   generated_possibilities.sort((a, b) => a.weekMax < b.weekMax);

--- a/js/predictions.js
+++ b/js/predictions.js
@@ -646,12 +646,23 @@ function analyze_possibilities(sell_prices, first_buy, previous_pattern) {
   for (let poss of generated_possibilities) {
     var weekMins = [];
     var weekMaxes = [];
+    var futureMins = [];
     for (let day of poss.prices.slice(2)) {
+      //If min == max, the date is in the past
+      if(day.min == day.max) {
+        futureMins = []
+      }
+      else {
+        futureMins.push(day.min);
+      }
       weekMins.push(day.min);
       weekMaxes.push(day.max);
     }
     poss.weekGuaranteedMinimum = Math.max(...weekMins);
     poss.weekMax = Math.max(...weekMaxes);
+	poss.futureMin = Math.max(...futureMins);
+	console.log(poss.futureMins)
+	console.log(poss.futureMin);
   }
 
   generated_possibilities.sort((a, b) => a.weekMax < b.weekMax);

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -175,7 +175,7 @@ const calculateOutput = function (data, first_buy, previous_pattern) {
         out_line += `<td>${day.min}</td>`;
       }
     }
-    out_line += `<td>${poss.weekGuaranteedMinimum}</td><td>${poss.weekMax}</td></tr>`;
+    out_line += `<td>${poss.weekGuaranteedMinimum}</td><td>${poss.futureMin}<td>${poss.weekMax}</td></tr>`;
     output_possibilities += out_line
   }
 


### PR DESCRIPTION
Implemented idea from https://github.com/mikebryant/ac-nh-turnip-prices/issues/43

The guaranteed minimum column could include a past value, this change will add another column that only figures in future values.