### PR TITLE
Provides consistent cross-browser sorting behavior.

### DIFF
--- a/js/predictions.js
+++ b/js/predictions.js
@@ -654,7 +654,15 @@ function analyze_possibilities(sell_prices, first_buy, previous_pattern) {
     poss.weekMax = Math.max(...weekMaxes);
   }
 
-  generated_possibilities.sort((a, b) => a.weekMax < b.weekMax);
+  generated_possibilities.sort((a, b) => {
+    if (a.weekMax < b.weekMax) {
+      return 1;
+    } else if (a.weekMax > b.weekMax) {
+      return -1;
+    } else {
+      return 0;
+    }
+  });
 
   return generated_possibilities;
 }


### PR DESCRIPTION
Changes the sorting in `generate_possibilities` to have the intended effect. 

The old version worked on Firefox, but did not sort the list on Chrome because `a.weekMax < b.weekMax` does not return `-1` if `a.weekMax > b.weekMax`.