### PR TITLE
fix: Move input trigger out of local storage block, so it still loads…

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -77,10 +77,11 @@ const initialize = function () {
     } else {
       fillFields(prices, first_buy, previous_pattern)
     }
-    $(document).trigger("input");
   } catch (e) {
     console.error(e);
   }
+
+  $(document).trigger("input");
 
   $("#permalink-btn").on("click", copyPermalink)
 


### PR DESCRIPTION
… the UI even if we have no storage

Fixes #161