### PR TITLE
Update zh-CN.json

### DIFF
--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -22,8 +22,8 @@
     "decreasing": "递减型",
     "fluctuating": "波动型",
     "unknown": "不知道",
-    "large-spike": "大幅上涨（四期型）",
-    "small-spike": "小幅上涨（三期型）"
+    "large-spike": "大幅上涨（三期型）",
+    "small-spike": "小幅上涨（四期型）"
   },
   "prices": {
     "description": "本周你的岛上大头菜的购买价格是多少？<i>（如果你是第一次购买大头菜，这个字段不可用）</i>",


### PR DESCRIPTION
Part of the large-spike / small-spike translation is swapped.

(The "small-spike" is called "四期型" because the price would increase four (四) times in the week, and "large-spike" == "三期型" because the price would increase three (三) times in the week.)