### PR TITLE
dropping 三期型、四期型

### DIFF
--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -22,8 +22,8 @@
     "decreasing": "递减型",
     "fluctuating": "波动型",
     "unknown": "不知道",
-    "large-spike": "大幅上涨（三期型）",
-    "small-spike": "小幅上涨（四期型）"
+    "large-spike": "大幅上涨",
+    "small-spike": "小幅上涨"
   },
   "prices": {
     "description": "本周你的岛上大头菜的购买价格是多少？<i>（如果你是第一次购买大头菜，这个字段不可用）</i>",
@@ -42,7 +42,7 @@
     "wednesday": "周三",
     "thursday": "周四",
     "friday": "周五",
-    "saturday" : "周六",
+    "saturday": "周六",
     "sunday": "周日",
     "abr": {
       "monday": "周一",
@@ -50,7 +50,7 @@
       "wednesday": "周三",
       "thursday": "周四",
       "friday": "周五",
-      "saturday" : "周六"
+      "saturday": "周六"
     }
   },
   "times": {

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -20,10 +20,10 @@
     "pattern": "模型",
     "all": "所有模型",
     "decreasing": "遞減型",
-    "fluctuating": "波型",
+    "fluctuating": "波動型",
     "unknown": "不知道",
-    "large-spike": "三期型",
-    "small-spike": "四期型"
+    "large-spike": "大幅上漲",
+    "small-spike": "小幅上漲"
   },
   "prices": {
     "description": "本週大頭菜的購買價格是多少？<i>(如果這是您第一次購買大頭菜，則此欄位會被停用)</i>",
@@ -42,7 +42,7 @@
     "wednesday": "星期三",
     "thursday": "星期四",
     "friday": "星期五",
-    "saturday" : "星期六",
+    "saturday": "星期六",
     "sunday": "星期日",
     "abr": {
       "monday": "週一",
@@ -50,7 +50,7 @@
       "wednesday": "週三",
       "thursday": "週四",
       "friday": "週五",
-      "saturday" : "週六"
+      "saturday": "週六"
     }
   },
   "times": {


### PR DESCRIPTION
https://github.com/mikebryant/ac-nh-turnip-prices/pull/165#discussion_r410357473

> Would recommend dropping the `（四期型）` and `（三期型）` off these translations. Those suggest a numerical order ot the patterns that both does not map to the order the buttons appear on the website, and possibly worse they also don't match up to their in-game pattern number which would likely end up confusing people who are familiar with the extracted game code.

