### PR TITLE
Change script ordering to fix iOS & Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,9 +311,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/i18next-browser-languagedetector/4.0.2/i18nextBrowserLanguageDetector.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-i18next/1.2.1/jquery-i18next.min.js"></script>
   <script src="js/chart.js"></script>
-  <script src="js/translations.js"></script>
   <script src="js/predictions.js"></script>
   <script src="js/scripts.js"></script>
+  <script src="js/translations.js"></script>
   <script src="js/contributors.js"></script>
   <script>
     // Check compatibility for the browser we're running this in
@@ -338,5 +338,4 @@
     }
   </script>
 </body>
-
 </html>


### PR DESCRIPTION
Due to the missing `initialize` variable in `translations.js` (initialize is defined in `scripts.js`) there is a `ReferenceError: Can't find variable: initialize` being thrown breaking iOS & Safari.

Ideally the app should be compiled via RollUp or another bundler, but fixing the script order works as well.

![Screen Shot 2020-04-18 at 1 35 03 PM](https://user-images.githubusercontent.com/67945/79670644-70b29880-8179-11ea-8b33-d166b2a0e201.png)