### PR TITLE
Classes in table

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -275,7 +275,7 @@ const calculateOutput = function (data, first_buy, previous_pattern) {
         out_line += `<td>${day.min}</td>`;
       }
     }
-    out_line += `<td>${poss.weekGuaranteedMinimum}</td><td>${poss.weekMax}</td></tr>`;
+    out_line += `<td class="week-min">${poss.weekGuaranteedMinimum}</td><td class="week-max">${poss.weekMax}</td></tr>`;
     output_possibilities += out_line
   }
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -273,7 +273,7 @@ const calculateOutput = function (data, first_buy, previous_pattern) {
         var dayContainsWeekMax = day.max === poss.weekMax || day.min === poss.weekMax;
 
         var minClass = dayContainsLowestGuaranteed ? `class="lowest" ` : null;
-        var maxClass = dayContainsWeekMax ? `clasws="highest" ` : null;
+        var maxClass = dayContainsWeekMax ? `class="highest" ` : null;
         var rangeClass = maxClass ? maxClass : (minClass ? minClass : null);
       if (day.min !== day.max) {
         out_line += `<td ${!!rangeClass ? rangeClass : ''}data-min="${day.min}" data-max="${day.max}">${day.min} ${i18next.t("output.to")} ${day.max}</td>`;

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -269,16 +269,17 @@ const calculateOutput = function (data, first_buy, previous_pattern) {
     }
     out_line += `<td>${percentage_display(poss.probability)}</td>`;
     for (let day of poss.prices.slice(1)) {
-        var dayContainsLowestGuaranteed = day.min === poss.weekGuaranteedMinimum;
-        var dayContainsWeekMax = day.max === poss.weekMax || day.min === poss.weekMax;
+      var dayContainsLowestGuaranteed = day.min === poss.weekGuaranteedMinimum;
+      var dayContainsWeekMax = day.max === poss.weekMax || day.min === poss.weekMax;
 
-        var minClass = dayContainsLowestGuaranteed ? `class="lowest" ` : null;
-        var maxClass = dayContainsWeekMax ? `class="highest" ` : null;
-        var rangeClass = maxClass ? maxClass : (minClass ? minClass : null);
+      var minClass = dayContainsLowestGuaranteed ? `class="lowest" ` : '';
+      var maxClass = dayContainsWeekMax ? `class="highest" ` : '';
+      var tdClass = maxClass ? maxClass : (minClass ? minClass : '');
+
       if (day.min !== day.max) {
-        out_line += `<td ${!!rangeClass ? rangeClass : ''}data-min="${day.min}" data-max="${day.max}">${day.min} ${i18next.t("output.to")} ${day.max}</td>`;
+        out_line += `<td ${tdClass}data-min="${day.min}" data-max="${day.max}">${day.min} ${i18next.t("output.to")} ${day.max}</td>`;
       } else {
-        out_line += `<td ${!!maxClass ? maxClass : ''}data-min="${day.min}" data-max="${day.min}">${day.min}</td>`;
+        out_line += `<td ${tdClass}data-min="${day.min}" data-max="${day.min}">${day.min}</td>`;
       }
     }
     out_line += `<td class="week-min">${poss.weekGuaranteedMinimum}</td><td class="week-max">${poss.weekMax}</td></tr>`;

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -269,10 +269,16 @@ const calculateOutput = function (data, first_buy, previous_pattern) {
     }
     out_line += `<td>${percentage_display(poss.probability)}</td>`;
     for (let day of poss.prices.slice(1)) {
+        var dayContainsLowestGuaranteed = day.min === poss.weekGuaranteedMinimum;
+        var dayContainsWeekMax = day.max === poss.weekMax || day.min === poss.weekMax;
+
+        var minClass = dayContainsLowestGuaranteed ? `class="lowest" ` : null;
+        var maxClass = dayContainsWeekMax ? `clasws="highest" ` : null;
+        var rangeClass = maxClass ? maxClass : (minClass ? minClass : null);
       if (day.min !== day.max) {
-        out_line += `<td>${day.min} ${i18next.t("output.to")} ${day.max}</td>`;
+        out_line += `<td ${!!rangeClass ? rangeClass : ''}data-min="${day.min}" data-max="${day.max}">${day.min} ${i18next.t("output.to")} ${day.max}</td>`;
       } else {
-        out_line += `<td>${day.min}</td>`;
+        out_line += `<td ${!!maxClass ? maxClass : ''}data-min="${day.min}" data-max="${day.min}">${day.min}</td>`;
       }
     }
     out_line += `<td class="week-min">${poss.weekGuaranteedMinimum}</td><td class="week-max">${poss.weekMax}</td></tr>`;


### PR DESCRIPTION
Adds some class names and `[data-min]` and `[data-max]` attributes to support styling in the future.

This adds no styling whatsoever, but seeks to lay the groundwork that can be used to solve some existing, open issues such as #12, #124, etc.

I didn't want to style now due to the design and accessibility considerations that should be taken to ensure the best results.