### PR TITLE
Add Discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ac-nh-turnip-prices
+<a href="https://discord.gg/bRh74X8">
+    <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
+  </a>
+  
 Price calculator/predictor for Turnip prices
-
 ## Scope
 
 This tool is:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ac-nh-turnip-prices
-<a href="https://discord.gg/bRh74X8">
-    <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
-  </a>
+[![discord](https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat)](https://discord.gg/bRh74X8)
   
 Price calculator/predictor for Turnip prices
 ## Scope


### PR DESCRIPTION
I have added a link to the Discord server in the README. Since the Discord is used for contributors to discuss, I do not think it would be wise to put it on the site so I just added its link in the README.
Closes #17 