### PR TITLE
Add cloud SVGs back without animation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -489,39 +489,21 @@ input[type=number] {
   to {bottom: 0; opacity: 0;}
 }
 
-/* Animation */
-.parallax>use {
-  animation: move-forever 25s cubic-bezier(.55, .5, .45, .5) infinite;
-}
-
+/* Cloud SVG placement */
 .parallax>use:nth-child(1) {
-  animation-delay: -2s;
-  animation-duration: 7s;
+  transform: translate3d(-30px, 0, 0);
 }
 
 .parallax>use:nth-child(2) {
-  animation-delay: -3s;
-  animation-duration: 10s;
+  transform: translate3d(-90px, 0, 0);
 }
 
 .parallax>use:nth-child(3) {
-  animation-delay: -4s;
-  animation-duration: 13s;
+  transform: translate3d(45px, 0, 0);
 }
 
 .parallax>use:nth-child(4) {
-  animation-delay: -5s;
-  animation-duration: 20s;
-}
-
-@keyframes move-forever {
-  0% {
-    transform: translate3d(-90px, 0, 0);
-  }
-
-  100% {
-    transform: translate3d(85px, 0, 0);
-  }
+  transform: translate3d(20px, 0, 0);
 }
 
 /*Shrinking for mobile*/

--- a/index.html
+++ b/index.html
@@ -54,7 +54,24 @@
   <div class="nook-phone">
     <h1>Turnip Prophet</h1>
 
+    <div>
+      <svg class="waves" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+        viewBox="0 24 150 28" preserveAspectRatio="none" shape-rendering="auto">
+        <defs>
+          <path id="gentle-wave" d="M-160 44c30 0 58-18 88-18s 58 18 88 18 58-18 88-18 58 18 88 18 v44h-352z" />
+        </defs>
+        <g class="parallax">
+          <use xlink:href="#gentle-wave" x="48" y="0" fill="rgba(255,255,255,0.6" />
+          <use xlink:href="#gentle-wave" x="48" y="3" fill="rgba(255,255,255,0.4)" />
+          <use xlink:href="#gentle-wave" x="48" y="5" fill="rgba(255,255,255,0.2)" />
+          <use xlink:href="#gentle-wave" x="48" y="7" fill="#fff" />
+        </g>
+      </svg>
+    </div>
+
     <div class="nook-phone-center">
+
+
 
       <form class="input__form">
         <div class="form__row">
@@ -248,6 +265,21 @@
           <tbody id="output"></tbody>
         </table>
       </div>
+    </div>
+
+    <div style="transform:rotate(180deg)">
+      <svg class="waves" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+        viewBox="0 24 150 28" preserveAspectRatio="none" shape-rendering="auto">
+        <defs>
+          <path id="gentle-wave" d="M-160 44c30 0 58-18 88-18s 58 18 88 18 58-18 88-18 58 18 88 18 v44h-352z" />
+        </defs>
+        <g class="parallax">
+          <use xlink:href="#gentle-wave" x="48" y="0" fill="rgba(255,255,255,0.6" />
+          <use xlink:href="#gentle-wave" x="48" y="3" fill="rgba(255,255,255,0.4)" />
+          <use xlink:href="#gentle-wave" x="48" y="5" fill="rgba(255,255,255,0.2)" />
+          <use xlink:href="#gentle-wave" x="48" y="7" fill="#fff" />
+        </g>
+      </svg>
     </div>
   </div>
 


### PR DESCRIPTION
This is a slightly different approach to the performance fixes in #229 for #155 that allows the cloud SVGs to remain, without the animations that were heavy on lower end devices.

Fixes #155 