### PR TITLE
Shrink L/R padding on turnip table to fix overflow

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -382,7 +382,7 @@ input[type=number] {
 #turnipTable td {
   white-space: nowrap;
   max-width: 150px;
-  padding: 6px 4px;
+  padding: 6px 2px;
   text-align: center;
   border-right: 1px solid rgba(0, 0, 0, 0.03);
   border-bottom: 1px solid rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
Prevents overflow on desktop early in the week when only the Sunday price is known.

This is the simplest fix to #269 I could find. 

Discussion and alternate options encouraged. 