### PR TITLE
Add iOS number pad support

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
           <h6 data-i18n="weekdays.sunday"></h6>
           <div class="input__group">
             <label data-i18n="[html]prices.description"></label>
-            <input type="number" id="buy" placeholder="..." />
+            <input type="number" pattern="\d*" id="buy" placeholder="..." />
 
           </div>
         </div>
@@ -121,11 +121,11 @@
             <h6 data-i18n="weekdays.monday"></h6>
             <div class="input__group">
               <label data-i18n="times.morning" for="sell_2"></label>
-              <input type="number" id="sell_2" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_2" placeholder="..." />
             </div>
             <div class="input__group">
               <label data-i18n="times.afternoon" for="sell_3"></label>
-              <input type="number" id="sell_3" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_3" placeholder="..." />
             </div>
           </div>
 
@@ -133,11 +133,11 @@
             <h6 data-i18n="weekdays.tuesday"></h6>
             <div class="input__group">
               <label data-i18n="times.morning" for="sell_4"></label>
-              <input type="number" id="sell_4" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_4" placeholder="..." />
             </div>
             <div class="input__group">
               <label data-i18n="times.afternoon" for="sell_5"></label>
-              <input type="number" id="sell_5" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_5" placeholder="..." />
             </div>
           </div>
 
@@ -145,11 +145,11 @@
             <h6 data-i18n="weekdays.wednesday"></h6>
             <div class="input__group">
               <label data-i18n="times.morning" for="sell_6"></label>
-              <input type="number" id="sell_6" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_6" placeholder="..." />
             </div>
             <div class="input__group">
               <label data-i18n="times.afternoon" for="sell_7"></label>
-              <input type="number" id="sell_7" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_7" placeholder="..." />
             </div>
           </div>
 
@@ -157,11 +157,11 @@
             <h6 data-i18n="weekdays.thursday"></h6>
             <div class="input__group">
               <label data-i18n="times.morning" for="sell_8"></label>
-              <input type="number" id="sell_8" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_8" placeholder="..." />
             </div>
             <div class="input__group">
               <label data-i18n="times.afternoon" for="sell_9"></label>
-              <input type="number" id="sell_9" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_9" placeholder="..." />
             </div>
           </div>
 
@@ -169,11 +169,11 @@
             <h6 data-i18n="weekdays.friday"></h6>
             <div class="input__group">
               <label data-i18n="times.morning" for="sell_10"></label>
-              <input type="number" id="sell_10" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_10" placeholder="..." />
             </div>
             <div class="input__group">
               <label data-i18n="times.afternoon" for="sell_11"></label>
-              <input type="number" id="sell_11" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_11" placeholder="..." />
             </div>
           </div>
 
@@ -181,11 +181,11 @@
             <h6 data-i18n="weekdays.saturday"></h6>
             <div class="input__group">
               <label data-i18n="times.morning" for="sell_12"></label>
-              <input type="number" id="sell_12" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_12" placeholder="..." />
             </div>
             <div class="input__group">
               <label data-i18n="times.afternoon" for="sell_13"></label>
-              <input type="number" id="sell_13" placeholder="..." />
+              <input type="number" pattern="\d*" id="sell_13" placeholder="..." />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR adds a numeric regex pattern to each of the price inputs to enable iOS' number pad keyboard for price entry:

![IMG_0410](https://user-images.githubusercontent.com/5166470/80396354-5d828580-8869-11ea-8a48-b2ddee05d57b.PNG)