### PR TITLE
Fix incorrect "Guaranteed Minimum"

### DIFF
--- a/js/predictions.js
+++ b/js/predictions.js
@@ -954,7 +954,7 @@ class Predictor {
         weekMins.push(poss.prices[poss.prices.length -1].min);
         weekMaxes.push(poss.prices[poss.prices.length -1].max);
       }
-      poss.weekGuaranteedMinimum = Math.max(...weekMins);
+      poss.weekGuaranteedMinimum = Math.min(...weekMins);
       poss.weekMax = Math.max(...weekMaxes);
     }
 


### PR DESCRIPTION
Spotted something odd where my "Guaranteed minimum" was greater than my current prices

https://turnipprophet.io?prices=96.87.83.73.74........

Digging through the code, I think this line is the mistake. The guaranteed minimum should be the lowest of day-by-day minimums, right?