### PR TITLE
fix: Fall back to more generic languages for selection box default

### DIFF
--- a/js/translations.js
+++ b/js/translations.js
@@ -3,6 +3,24 @@ function updateContent() {
   $('body').localize();
 }
 const defaultLanguage = 'en';
+const LANGUAGES = {
+  'ca': 'Català',
+  'de': 'Deutsch',
+  'en': 'English',
+  'es-ES': 'Español',
+  'fr': 'Français',
+  'hu': 'magyar',
+  'it': 'Italiano',
+  'ja': '日本語',
+  'ko': '한국어',
+  'nl': 'Nederlands',
+  'pl': 'Polski',
+  'pt-BR': 'Português',
+  'ru': 'Русский',
+  'th-TH': 'ไทย',
+  'zh-CN': '简体中文',
+  'zh-TW': '繁體中文',
+};
 i18next
 .use(i18nextXHRBackend)
 .use(i18nextBrowserLanguageDetector)
@@ -13,30 +31,16 @@ i18next
     loadPath: 'locales/{{lng}}.json',
   },
 }, (err, t) => {
-  const languages = [
-    ['ca', 'Català'],
-    ['de', 'Deutsch'],
-    ['en', 'English'],
-    ['es-ES', 'Español'],
-    ['fr', 'Français'],
-    ['hu', 'magyar'],
-    ['it', 'Italiano'],
-    ['ja', '日本語'],
-    ['ko', '한국어'],
-    ['nl', 'Nederlands'],
-    ['pt-BR', 'Português'],
-    ['ru', 'Русский'],
-    ['zh-CN', '简体中文'],
-    ['zh-TW', '繁體中文'],
-    ['th-TH', 'ไทย'],
-    ['pl', 'Polski'],
-  ].sort(),
   languageSelector = $('#language');
-  languages.map(([code, name]) => {
-    languageSelector.append(`<option value="${code}"${code == i18next.language ? ' selected' : ''}>${name}</option>`);
-  });
-  if (!languageSelector.find('[selected]').length)
-    languageSelector.val(defaultLanguage);
+  for (let [code, name] of Object.entries(LANGUAGES)) {
+    languageSelector.append(`<option value="${code}">${name}</option>`);
+  }
+  for (let code of i18next.languages) {
+    if (code in LANGUAGES) {
+      languageSelector.val(code);
+      break;
+    }
+  }
   languageSelector.on('change', function () {
     if (this.value == i18next.language)
       return;
@@ -44,11 +48,6 @@ i18next
   });
   jqueryI18next.init(i18next, $);
   i18next.on('languageChanged', lng => {
-    if (!languageSelector.find(`[value=${lng}]`).length) {
-      i18next.changeLanguage(defaultLanguage);
-      return;
-    }
-    languageSelector.val(lng);
     updateContent();
   });
   // init set content

--- a/js/translations.js
+++ b/js/translations.js
@@ -7,7 +7,7 @@ const LANGUAGES = {
   'ca': 'Català',
   'de': 'Deutsch',
   'en': 'English',
-  'es-ES': 'Español',
+  'es': 'Español',
   'fr': 'Français',
   'hu': 'magyar',
   'it': 'Italiano',
@@ -17,9 +17,9 @@ const LANGUAGES = {
   'pl': 'Polski',
   'pt-BR': 'Português',
   'ru': 'Русский',
-  'th-TH': 'ไทย',
+  'th': 'ไทย',
   'zh-CN': '简体中文',
-  'zh-TW': '繁體中文',
+  'zh-TW': '繁體中文'
 };
 i18next
 .use(i18nextXHRBackend)


### PR DESCRIPTION
Try to fall back gracefully, using the list of fallback languages in the i18next list

Fixes #289 