### PR TITLE
adding delay after user input to prevent jank as chart refreshes

### DIFF
--- a/js/translations.js
+++ b/js/translations.js
@@ -51,6 +51,15 @@ i18next
   });
   // init set content
   $(document).ready(initialize);
-  $(document).on('input', updateContent);
+
+  let delayTimer;
+  $(document).on('input', function() {
+    // adding short delay after input to help mitigate potential lag after keystrokes
+    clearTimeout(delayTimer);
+    delayTimer = setTimeout(function() {
+      updateContent();
+    }, 1000);
+  });
+
   $('input[type = radio]').on('change', updateContent);
 });

--- a/js/translations.js
+++ b/js/translations.js
@@ -58,7 +58,7 @@ i18next
     clearTimeout(delayTimer);
     delayTimer = setTimeout(function() {
       updateContent();
-    }, 1000);
+    }, 500);
   });
 
   $('input[type = radio]').on('change', updateContent);


### PR DESCRIPTION
I've noticed that there's a bit of lag whenever typing in the input fields, and thought I could help. It's not always so bad on desktop, but especially janky on mobile.

This timeout delay stops the chart from rendering until 1000ms after the last keystroke, and helps ensure that sets of data can be input without re-rendering the chart after each keystroke.