### PR TITLE
Add pagination support for fetching contributors from Github

### DIFF
--- a/js/contributors.js
+++ b/js/contributors.js
@@ -19,6 +19,8 @@ function getContributors(page) {
           }
         });
         container.append(contributorList.join(''));
+        // If the length of the data is < 100, we know we are processing the last page of data.
+        if (data.length < 100) return; 
         getContributors(page + 1);
       });
   }

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -9,8 +9,12 @@ function getContributors(page) {
 
         const contributorList = [];
         data.forEach((contributor, idx) => {
+          if (idx === 0 && page > 1) {
+            contributorList.push(', ');
+          }
+
           contributorList.push(`<a href="${contributor.html_url}">${contributor.login}</a>`);
-          if (idx < data.length - 1 || page > 1) {
+          if (idx < data.length - 1) {
             contributorList.push(', ');
           }
         });

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -1,6 +1,6 @@
 function getContributors(page) {
   if (window.jQuery) {
-    const container = $("#contributors");
+    const container = $('#contributors');
     jQuery.ajax(`https://api.github.com/repos/mikebryant/ac-nh-turnip-prices/contributors?page=${page}`, {})
       .done(function (data) {
         if (data.length === 0) {
@@ -13,10 +13,10 @@ function getContributors(page) {
             `<a href="${contributor.html_url}">${contributor.login}</a>`
           );
           if (idx < data.length - 1) {
-            contributorList.push(", ");
+            contributorList.push(', ');
           }
         });
-        container.append(contributorList.join(""));
+        container.append(contributorList.join(''));
         getContributors(page + 1);
       });
   }

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -9,9 +9,7 @@ function getContributors(page) {
 
         const contributorList = [];
         data.forEach((contributor, idx) => {
-          contributorList.push(
-            `<a href="${contributor.html_url}">${contributor.login}</a>`
-          );
+          contributorList.push(`<a href="${contributor.html_url}">${contributor.login}</a>`);
           if (idx < data.length - 1) {
             contributorList.push(', ');
           }

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -1,18 +1,25 @@
-function getContributors() {
+function getContributors(page) {
   if (window.jQuery) {
-    const container = $('#contributors');
-    jQuery.ajax('https://api.github.com/repos/mikebryant/ac-nh-turnip-prices/contributors', {})
+    const container = $("#contributors");
+    jQuery.ajax(`https://api.github.com/repos/mikebryant/ac-nh-turnip-prices/contributors?page=${page}`, {})
       .done(function (data) {
+        if (data.length === 0) {
+          return;
+        }
+
         const contributorList = [];
         data.forEach((contributor, idx) => {
-          contributorList.push(`<a href="${contributor.html_url}">${contributor.login}</a>`);
+          contributorList.push(
+            `<a href="${contributor.html_url}">${contributor.login}</a>`
+          );
           if (idx < data.length - 1) {
-            contributorList.push(', ');
+            contributorList.push(", ");
           }
         });
-        container.append(contributorList.join(''));
+        container.append(contributorList.join(""));
+        getContributors(page + 1);
       });
   }
 }
 
-$(document).ready(getContributors);
+$(document).ready(getContributors(1));

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -3,10 +3,6 @@ function getContributors(page) {
     const container = $('#contributors');
     jQuery.ajax(`https://api.github.com/repos/mikebryant/ac-nh-turnip-prices/contributors?page=${page}&per_page=100`, {})
       .done(function (data) {
-        if (data.length === 0) {
-          return;
-        }
-
         const contributorList = [];
         data.forEach((contributor, idx) => {
           if (idx === 0 && page > 1) {

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -10,7 +10,7 @@ function getContributors(page) {
         const contributorList = [];
         data.forEach((contributor, idx) => {
           contributorList.push(`<a href="${contributor.html_url}">${contributor.login}</a>`);
-          if (idx < data.length - 1) {
+          if (idx < data.length - 1 || page > 1) {
             contributorList.push(', ');
           }
         });

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -1,7 +1,7 @@
 function getContributors(page) {
   if (window.jQuery) {
     const container = $('#contributors');
-    jQuery.ajax(`https://api.github.com/repos/mikebryant/ac-nh-turnip-prices/contributors?page=${page}`, {})
+    jQuery.ajax(`https://api.github.com/repos/mikebryant/ac-nh-turnip-prices/contributors?page=${page}&per_page=100`, {})
       .done(function (data) {
         if (data.length === 0) {
           return;

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -1,7 +1,8 @@
 function getContributors(page) {
+  const PER_PAGE = 100
   if (window.jQuery) {
     const container = $('#contributors');
-    jQuery.ajax(`https://api.github.com/repos/mikebryant/ac-nh-turnip-prices/contributors?page=${page}&per_page=100`, {})
+    jQuery.ajax(`https://api.github.com/repos/mikebryant/ac-nh-turnip-prices/contributors?page=${page}&per_page=${PER_PAGE}`, {})
       .done(function (data) {
         const contributorList = [];
         data.forEach((contributor, idx) => {
@@ -15,8 +16,8 @@ function getContributors(page) {
           }
         });
         container.append(contributorList.join(''));
-        // If the length of the data is < 100, we know we are processing the last page of data.
-        if (data.length < 100) return; 
+        // If the length of the data is < PER_PAGE, we know we are processing the last page of data.
+        if (data.length < PER_PAGE) return; 
         getContributors(page + 1);
       });
   }


### PR DESCRIPTION
An alternative approach to #302: Instead of a manually updated contributors list, this extends the current `getContributors` function to make paginated calls to Github API to get all contributors. 

Pros:
No manual work required when new contributors are added.
Extends code that is already working in production, so less risk.

Cons:
Makes additional calls to the Github API (n/30 calls where n = # of contributors).

Screenshots:
Current Live Site:
![image](https://user-images.githubusercontent.com/6795991/80734911-86a74e00-8ad5-11ea-9662-865904553682.png)

Proposed Change:
![image](https://user-images.githubusercontent.com/6795991/80735301-1a791a00-8ad6-11ea-822e-9a68a7156931.png)

