### PR TITLE
#314 Fix Predictions are calculated twice when radios are toggled

### DIFF
--- a/js/translations.js
+++ b/js/translations.js
@@ -55,7 +55,9 @@ i18next
   $(document).ready(initialize);
 
   let delayTimer;
-  $(document).on('input', function() {
+  $(document).on('input', function(event) {
+    //prevent radio input from updating content twice per input change
+    if(event.target.type === 'radio'){ return }
     // adding short delay after input to help mitigate potential lag after keystrokes
     clearTimeout(delayTimer);
     delayTimer = setTimeout(function() {


### PR DESCRIPTION
Fixes https://github.com/mikebryant/ac-nh-turnip-prices/issues/314

Since radio buttons are subject to both the `document.input` event and the `input[type = radio].change` event the content is updated twice every time a radio group's value is changed.

I did not remove the change event altogether; although it should work , [MDN ](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) says: 
> For <input> elements with type=checkbox or type=radio, the input event should fire whenever a user toggles the control, per the HTML5 specification. However, historically this has not always been the case. Check compatibility, or use the change event instead for elements of these types.

So I went for a guard clause on the overall input event.

A further suggestion of mine is to bind the event to every input tag and not the document, but I haven't analyzed the project enough to make that PR.

Anyway, cheers!