### PR TITLE
Fix #317 -- Margin discrepancy light dark mode

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -568,23 +568,12 @@ input[type=number] {
   outline: none;
 }
 
-div.darkmode-background{
+div.darkmode-background {
   background: #fef0e3;
   background-image:
     radial-gradient(#fff 20%, transparent 0),
     radial-gradient(#fff 20%, transparent 0);
-  position: inherit;
-}
-
-body.darkmode--activated{
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-family: 'Varela Round', sans-serif;
-  width: 100%;
-  margin: 0 0 0 0;
-  position: absolute;
+  position: fixed;
 }
 
 body.darkmode--activated div[class^="dialog-box"],

--- a/css/styles.css
+++ b/css/styles.css
@@ -573,6 +573,10 @@ div.darkmode-background {
   background-image:
     radial-gradient(#fff 20%, transparent 0),
     radial-gradient(#fff 20%, transparent 0);
+  position: static;
+}
+
+.darkmode--activated .darkmode-background {
   position: fixed;
 }
 


### PR DESCRIPTION
https://github.com/mikebryant/ac-nh-turnip-prices/issues/317

Making the darkmode-background `position: fixed;` and removing the `position: absolute;` and `margin: 0;` from the body when darkmode is activated is a clean fix for this. There's also some redundant body styles that I removed.

As a side note, I did notice this 'waves' SVG is interfering with darkmode. Not sure if it should still be there?
![image](https://user-images.githubusercontent.com/30223207/80806021-de8ca480-8bfc-11ea-98bb-79a79e15de3c.png)
