### PR TITLE
remove overflow property from nook-phone css class

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -42,7 +42,6 @@ h2 {
   padding-bottom: 16px;
   background: #F5F8FF;
   color: #686868;
-  overflow: hidden;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 


### PR DESCRIPTION
Don't see any presentation affected in Chrome, Edge, or Firefox on both desktop and mobile. Fixes issue #331 