### PR TITLE
Improve Polish translations

### DIFF
--- a/locales/pl.json
+++ b/locales/pl.json
@@ -3,7 +3,7 @@
     "daisy-mae": "Daisy Mae"
   },
   "welcome": {
-    "salutation": "Cześć, witam w aplikacji <b>Turnip Prophet</b> na Twoim Nook Phone.",
+    "salutation": "Cześć, witaj w aplikacji <b>Turnip Prophet</b> na Twoim Nook Phone.",
     "description": "Ta aplikacja pozwoli Ci codziennie śledzić ceny rzep na twojej wyspie, jednak będziesz musiał uzupełniać je samodzielnie.",
     "conclusion": "Następnie aplikacja Turnip Prophet <b>w magiczny sposób</b> przewidzi jakie ceny rzep będziesz mieć przez resztę tygodnia"
   },
@@ -54,7 +54,7 @@
   },
   "times": {
     "morning": "Rano",
-    "afternoon": "Południe"
+    "afternoon": "Popołudnie"
   },
   "output": {
     "title": "Wyniki",
@@ -73,9 +73,9 @@
     "development": "Ta aplikacja wciąż jest w produkcji, lecz z czasem zostanie poprawiona!",
     "thanks": "Nie udałoby nam się to bez <a href=\"https://twitter.com/_Ninji/status/1244818665851289602?s=20\">pracy Ninji</a>, który dowiedział się jak Timmy and Tommy wyceniają rzepy.",
     "support": "Wsparcie, komentarze i wpłaty są możliwe pod adresem <a href=\"https://github.com/mikebryant/ac-nh-turnip-prices/issues\">Github</a>",
-    "sponsor": "Chcesz, wesprzeć twórców tego projektu? Wejdź na stronę <a href=\"https://github.com/mikebryant/ac-nh-turnip-prices#sponsor-button-repo\">GitHub</a> i wciśnij '❤ Sponsor'",
-    "contributors-text": "Oh! I nie zapominajmy o tych, którzy dotychczas nas wspierali!",
-    "contributors": "Fundatorzy",
+    "sponsor": "Chcesz wesprzeć twórców tego projektu? Wejdź na stronę <a href=\"https://github.com/mikebryant/ac-nh-turnip-prices#sponsor-button-repo\">GitHub</a> i wciśnij '❤ Sponsor'",
+    "contributors-text": "Aha! I nie zapominajmy o tych, którzy dotychczas nas wspierali!",
+    "contributors": "Współautorzy",
     "language": "Język"
   }
 }


### PR DESCRIPTION
Changes:
`witam` to `witaj` (more popular form used in software)
`południe` to `popołudnie` (original word means "noon", the new one means "afternoon")
Removed unnecessary comma in `"sponsor"`
`Oh!` to `Aha!` (better expression to show a sudden realization)
`Fundatorzy` to `współautorzy` (original word means "funders", changed to "co-authors" which is a lot closer to collaborators)