### PR TITLE
Add expected value info to chart and table

### DIFF
--- a/js/chart.js
+++ b/js/chart.js
@@ -28,10 +28,14 @@ function update_chart(input_data, possibilities) {
       data: possibilities[0].prices.slice(1).map(day => day.min),
       fill: false,
     }, {
+      label: i18next.t("output.chart.expected-value"),
+      data: possibilities[possibilities.length - 1].prices.slice(1).map(day => day.min),
+      fill: false,
+    }, {
       label: i18next.t("output.chart.maximum"),
       data: possibilities[0].prices.slice(1).map(day => day.max),
-      fill: "-1",
-    },
+      fill: "-2",
+    }
   ],
   labels = [i18next.t("weekdays.sunday")].concat(...[i18next.t("weekdays.abr.monday"), i18next.t("weekdays.abr.tuesday"), i18next.t("weekdays.abr.wednesday"), i18next.t("weekdays.abr.thursday"), i18next.t("weekdays.abr.friday"), i18next.t("weekdays.abr.saturday")].map(
       day => [i18next.t("times.morning"),

--- a/js/predictions.js
+++ b/js/predictions.js
@@ -975,11 +975,13 @@ class Predictor {
     });
 
     let global_min_max = [];
+    let expected_values = [];
     for (let day = 0; day < 14; day++) {
       const prices = {
         min: 999,
         max: 0,
       }
+      const weighted_expected_values = [];
       for (let poss of generated_possibilities) {
         if (poss.prices[day].min < prices.min) {
           prices.min = poss.prices[day].min;
@@ -987,8 +989,16 @@ class Predictor {
         if (poss.prices[day].max > prices.max) {
           prices.max = poss.prices[day].max;
         }
+        const expected_value = (poss.prices[day].min + poss.prices[day].max) / 2;
+        weighted_expected_values.push(poss.probability * expected_value);
       }
       global_min_max.push(prices);
+
+      let expected_value = Number(float_sum(weighted_expected_values).toFixed(3));
+      expected_values.push({
+        min: expected_value,
+        max: expected_value
+      });
     }
 
     generated_possibilities.unshift({
@@ -997,6 +1007,12 @@ class Predictor {
       prices: global_min_max,
       weekGuaranteedMinimum: Math.min(...generated_possibilities.map(poss => poss.weekGuaranteedMinimum)),
       weekMax: Math.max(...generated_possibilities.map(poss => poss.weekMax))
+    });
+
+    generated_possibilities.push({
+      pattern_description: i18next.t("patterns.expected-value"),
+      pattern_number: 5,
+      prices: expected_values,
     });
 
     return generated_possibilities;

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -308,7 +308,7 @@ const calculateOutput = function (data, first_buy, previous_pattern) {
 
     var min_class = getPriceClass(style_price, poss.weekGuaranteedMinimum);
     var max_class = getPriceClass(style_price, poss.weekMax);
-    out_line += `<td class='${min_class}'>${poss.weekGuaranteedMinimum}</td><td class='${max_class}'>${poss.weekMax}</td></tr>`;
+    out_line += `<td class='${min_class}'>${poss.weekGuaranteedMinimum || "—"}</td><td class='${max_class}'>${poss.weekMax || "—"}</td></tr>`;
     output_possibilities += out_line
   }
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -299,8 +299,10 @@ const calculateOutput = function (data, first_buy, previous_pattern) {
       let price_class = getPriceClass(style_price, day.max);
       if (day.min !== day.max) {
         out_line += `<td class='${price_class}'>${day.min} ${i18next.t("output.to")} ${day.max}</td>`;
-      } else {
+      } else if (day.min % 1 === 0) {
         out_line += `<td class='${price_class}'>${day.min}</td>`;
+      } else {
+        out_line += `<td class='${price_class}'>~${day.min.toFixed(1)}</td>`;
       }
     }
 

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -22,7 +22,8 @@
     "fluctuating": "Fluctuant",
     "unknown": "No ho sé",
     "large-spike": "Pic gran",
-    "small-spike": "Pic petit"
+    "small-spike": "Pic petit",
+    "expected-value": "Valor esperat"
   },
   "prices": {
     "description": "Quin ha sigut el preu de compra de naps a la teva illa aquesta setmana?",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "Preu d'entrada",
       "minimum": "Mínim garantit",
-      "maximum": "Màxim potencial"
+      "maximum": "Màxim potencial",
+      "expected-value": "Valor esperat"
     }
   },
   "textbox": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -22,7 +22,8 @@
     "fluctuating": "Schwankend",
     "unknown": "Ich weiß nicht",
     "large-spike": "Stark Ansteigend",
-    "small-spike": "Leicht Ansteigend"
+    "small-spike": "Leicht Ansteigend",
+    "expected-value": "Erwartungswert"
   },
   "prices": {
     "description": "Wie hoch war der Preis für Rüben diese Woche auf deiner Insel?",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "Eingegebener Preis",
       "minimum": "Garantiertes Minimum",
-      "maximum": "Potentielles Maximum"
+      "maximum": "Potentielles Maximum",
+      "expected-value": "Erwartungswert"
     }
   },
   "textbox": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,7 +22,8 @@
     "fluctuating": "Fluctuating",
     "unknown": "I don't know",
     "large-spike": "Large Spike",
-    "small-spike": "Small Spike"
+    "small-spike": "Small Spike",
+    "expected-value": "Expected value"
   },
   "prices": {
     "description": "What was the price of turnips this week on your island?",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "Input Price",
       "minimum": "Guaranteed Minimum",
-      "maximum": "Potential Maximum"
+      "maximum": "Potential Maximum",
+      "expected-value": "Expected Value"
     }
   },
   "textbox": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -22,7 +22,8 @@
     "fluctuating": "Fluctuante",
     "unknown": "No lo sé",
     "large-spike": "Pico alto",
-    "small-spike": "Pico moderado"
+    "small-spike": "Pico moderado",
+    "expected-value": "Valor esperado"
   },
   "prices": {
     "description": "¿Cuál fue el precio de los nabos en su isla esta semana?",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "Precio de entrada",
       "minimum": "Mínimo garantizado",
-      "maximum": "Máximo potencial"
+      "maximum": "Máximo potencial",
+      "expected-value": "Valor esperado"
     }
   },
   "textbox": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -22,7 +22,8 @@
     "fluctuating": "Variable",
     "unknown": "Je ne sais pas",
     "large-spike": "Grand Pic",
-    "small-spike": "Petit Pic"
+    "small-spike": "Petit Pic",
+    "expected-value": "Valeur attendue"
   },
   "prices": {
     "description": "À quel prix Porcelette vendait ses navets sur ton île cette semaine ?",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "Prix renseigné",
       "minimum": "Minimum Garanti",
-      "maximum": "Maximum Potentiel"
+      "maximum": "Maximum Potentiel",
+      "expected-value": "Valeur Attendue"
     }
   },
   "textbox": {

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -22,7 +22,8 @@
     "fluctuating": "Fluctuante",
     "unknown": "Descoñecido",
     "large-spike": "Pico grande",
-    "small-spike": "Pico pequeno"
+    "small-spike": "Pico pequeno",
+    "expected-value": "Esperanza"
   },
   "prices": {
     "description": "Que prezos tiveron os nabos esta semana na túa illa?",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "Prezo introducido",
       "minimum": "Mínimo garantido",
-      "maximum": "Máximo potencial"
+      "maximum": "Máximo potencial",
+      "expected-value": "Esperanza"
     }
   },
   "textbox": {

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -22,7 +22,8 @@
     "fluctuating": "Ingadozó",
     "unknown": "Nem tudom",
     "large-spike": "Nagy kiugrás",
-    "small-spike": "Kis kiugrás"
+    "small-spike": "Kis kiugrás",
+    "expected-value": "Várható érték"
   },
   "prices": {
     "description": "Mennyiért vettél ezen a héten retket?",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "Megadott ár",
       "minimum": "Garantált minimum",
-      "maximum": "Lehetséges maximum"
+      "maximum": "Lehetséges maximum",
+      "expected-value": "Várható érték"
     }
   },
   "textbox": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -23,7 +23,8 @@
     "fluctuating": "Oscillante",
     "unknown": "Non lo so!",
     "large-spike": "Grande picco",
-    "small-spike": "Piccolo picco"
+    "small-spike": "Piccolo picco",
+    "expected-value": "Valore atteso"
   },
   "prices": {
     "description": "Qual era il prezzo di acquisto delle rape sulla tua isola questa settimana?",
@@ -66,7 +67,8 @@
     "chart": {
       "input": "Prezzo Iniziale",
       "minimum": "Minimo Garantito",
-      "maximum": "Massimo Potenziale"
+      "maximum": "Massimo Potenziale",
+      "expected-value": "Valore atteso"
     }
   },
   "textbox": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -22,7 +22,8 @@
     "fluctuating": "波型",
     "unknown": "わかりません",
     "large-spike": "跳ね大型(3期型)",
-    "small-spike": "跳ね小型(4期型)"
+    "small-spike": "跳ね小型(4期型)",
+    "expected-value": "期待値"
   },
   "prices": {
     "description": "今週のカブ価は？",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "カブ価",
       "minimum": "保証される最小の収入",
-      "maximum": "予測される限界の収入"
+      "maximum": "予測される限界の収入",
+      "expected-value": "期待値"
     }
   },
   "textbox": {

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -22,7 +22,8 @@
     "fluctuating": "파동형",
     "unknown": "모름",
     "large-spike": "큰 급등",
-    "small-spike": "작은 급등"
+    "small-spike": "작은 급등",
+    "expected-value": "기대 값"
   },
   "prices": {
     "description": "이번 주에 당신의 섬에서 무를 샀을 때의 가격이 어떻게 됩니까?",
@@ -65,7 +66,8 @@
     "chart": {
       "input": "입력된 가격",
       "minimum": "최저 보장 가격",
-      "maximum": "가능한 최고 가격"
+      "maximum": "가능한 최고 가격",
+      "expected-value": "기대 값"
     }
   },
   "textbox": {


### PR DESCRIPTION
The expected value is the weighted average of each column of regular data
in the table. My island was roughly 50/50 large spike vs decreasing this morning, and without an expected value it's difficult to tell whether to cut my losses or wait  in hopes that it's the large spike.

Query params: `?prices=100.86.81.77.74.71.......&pattern=0`
![Screen Shot 2020-05-06 at 13 58 42](https://user-images.githubusercontent.com/1735904/81212670-33387280-8fa3-11ea-8780-e75fe54c6a4f.png)

To settle the suspense, today's PM price confirms I'm most likely getting the large spike!

Query params: `?prices=100.86.81.77.74.71.119......&pattern=0`
![Screen Shot 2020-05-06 at 13 59 09](https://user-images.githubusercontent.com/1735904/81212679-36336300-8fa3-11ea-9dc8-b0ebcb8f6acb.png)
