### PR TITLE
Change the Japanese translation of "chance"

### DIFF
--- a/locales/ja.json
+++ b/locales/ja.json
@@ -58,7 +58,7 @@
   },
   "output": {
     "title": "結果",
-    "chance": "% チャンス",
+    "chance": "% 確率",
     "to": "～",
     "minimum": "保証される最小の収入",
     "maximum": "予測される限界の収入",


### PR DESCRIPTION
"チャンス" is not totally wrong, but "確率" (direct translation of "probability") sounds more natural here.