### PR TITLE
Update URL whenever prices are filled

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -375,6 +375,7 @@ const update = function () {
   } else {
     permalink_button.hide();
   }
+  permalink && window.history.replaceState && window.history.replaceState({}, null, permalink);
   permalink_input.val(permalink);
 
   const prices = [buy_price, buy_price, ...sell_prices];


### PR DESCRIPTION
Not sure if its useful for others but I've had this issue on desktop & know at least one other friend with it too.

Basically, when you're tabbing through inputs and copy the URL from the url bar of your browser, the URL ends up being stale unless you explicitly click the Copy Permalink button. This fork automatically updates the url as you update it so you can easily Cmd/Ctrl + L and copy paste.