### PR TITLE
Fix data loss by preventing a call to update from running before data has been initialized.

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -36,6 +36,10 @@ const checkRadioByValue = function (radio_array, value) {
   radio_array.find(radio => radio.value == value).checked = true;
 };
 
+const state = {
+  initialized: false,
+};
+
 const sell_inputs = getSellFields();
 const buy_input = $("#buy");
 const first_buy_radios = getFirstBuyRadios();
@@ -92,6 +96,9 @@ const initialize = function () {
       update();
     }
   });
+
+  console.log('finished initializing');
+  state.initialized = true;
 };
 
 const updateLocalStorage = function (prices, first_buy, previous_pattern) {
@@ -364,6 +371,11 @@ const flashMessage = function(message) {
 };
 
 const update = function () {
+  if(!state.initialized){
+    console.log('update function called before initial data load');
+    // calls to update before the previous data has been initialized / loaded will reset the data.
+    return;
+  }
   const sell_prices = getSellPrices();
   const buy_price = parseInt(buy_input.val());
   const first_buy = getCheckedRadio(first_buy_radios) == 'true';


### PR DESCRIPTION
Debugging through this failure, i found occasionally the "update" call would be triggered by 
[Language Change events](https://github.com/mikebryant/ac-nh-turnip-prices/blob/master/js/translations.js#L52-L54) before the old data had been initialized.

this would cause the previously loaded data to be replaced with an array of nulls.

This should address #375 / #381 