### PR TITLE
Remove object spread operator so old edge works

### DIFF
--- a/js/predictions.js
+++ b/js/predictions.js
@@ -321,7 +321,7 @@ class Predictor {
 
   * multiply_generator_probability(generator, probability) {
     for (const it of generator) {
-      yield {...it, probability: it.probability * probability};
+      yield Object.assign({probability: it.probability * probability}, it);
     }
   }
 


### PR DESCRIPTION
Old edge doesn't support the spread operator for object literals. We can make a simple one line change that use Object.assign instead which does basically the same thing, but allows for users still using old edge to use the site.

We should consider a transpile step to fix this class of issues automatically for devs (and potentially show a banner warning for browsers that aren't supported)

Fixes #383 