### PR TITLE
Prevent from connection reset of code.jquery.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
 
   <div id="snackbar">Some text some message...</div>
 
-  <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/i18next/19.4.2/i18next.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/i18next-xhr-backend/3.2.2/i18nextXHRBackend.min.js"></script>


### PR DESCRIPTION
Use cdnjs as jquery source instead of code.jquery.com, because when I connected to turnipprophet.io, in Chrome console, it told me that it get Connection reset while connecting to code.jquery.com.

this caused page cannot correctly get jquery script, so it made the whole app not work.