### PR TITLE
Fixed some sentences

### DIFF
--- a/locales/es.json
+++ b/locales/es.json
@@ -25,7 +25,7 @@
     "small-spike": "Pico moderado"
   },
   "prices": {
-    "description": "¿Cuál fue el precio de los nabos en su isla esta semana?",
+    "description": "¿Cuál fue el precio de los nabos en tu isla esta semana?",
     "open": {
       "am": "AM - De 8:00 a 11:59",
       "pm": "PM - De 12:00 a 22:00"
@@ -69,7 +69,7 @@
     }
   },
   "textbox": {
-    "description": "Cuando introduzcas algunos precios, el Turnip Prophet empezará a hacer sus cálculos y te mostrará algunos posibles patrones para el precio de los nabos en tu isla.",
+    "description": "Cuando introduzcas algunos precios, Turnip Prophet empezará a hacer sus cálculos y te mostrará algunos posibles patrones para el precio de los nabos en tu isla.",
     "development": "Esta aplicación está aún en desarrollo, ¡pero la seguiremos mejorando!",
     "thanks": "Nada de esto habría sido posible sin el <a href=\"https://twitter.com/_Ninji/status/1244818665851289602?s=20\">trabajo de Ninji</a> para averiguar cómo Tendo y Nendo valoran los nabos.",
     "support": "Para asistencia, comentarios y contribuciones, no dudes en pasarte por <a href=\"https://github.com/mikebryant/ac-nh-turnip-prices/issues\">GitHub</a>.",


### PR DESCRIPTION
In spanish, we have two possessive adjectives, "tu" and "su". The first one is used in a informal conversation, the second one in a formal conversation. All the text is based in a informal conversation, but in line 28, there is the "su" possessive adjective.

In line 72, "el" cannot be added, as the noun "Turnip Prophet" is a proper noun.