### PR TITLE
Should sell now indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,11 @@
           <tbody id="output"></tbody>
         </table>
       </div>
+
+      <div class="form__row">
+        <h6 data-i18n="output.better.title"></h6>
+          <label id="betterLabel"></label>
+      </div>
     </div>
 
     <div style="transform:rotate(180deg)">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -335,7 +335,10 @@ const update_sellnow = function(prices, patterns) {
 
   let label = '';
 
-  if (now_index <= 1) {
+  if (patterns.length == 1) {
+    // invalid data
+    label = "---"
+  } else if (now_index <= 1) {
     // sunday
     label = i18next.t("output.better.cant")
   } else if (isNaN(prices[now_index])) {
@@ -343,6 +346,7 @@ const update_sellnow = function(prices, patterns) {
     label = i18next.t("output.better.no-data")
   } else {
     // calculate
+
     let now_price = prices[now_index]; // this is the base price
     var prob = 1 - patterns // probability of better is 1 minus probability of worst
       .slice(1) // discard the combined pattern (first in the list)
@@ -366,6 +370,7 @@ const update_sellnow = function(prices, patterns) {
     );
     label = `${probLabel} - ${i18next.t("output.better.details")} ${probNumber}`
   }
+
   // update
   $("#betterLabel").html(label);
 };

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -284,6 +284,7 @@ const displayPercentage = function(fraction) {
 const calculateOutput = function (data, first_buy, previous_pattern) {
   if (isEmpty(data)) {
     $("#output").html("");
+    $("#betterLabel").html("");
     return;
   }
   let pat_desc = {0:"fluctuating", 1:"large-spike", 2:"decreasing", 3:"small-spike", 4:"all"};

--- a/locales/en.json
+++ b/locales/en.json
@@ -66,6 +66,16 @@
       "input": "Input Price",
       "minimum": "Guaranteed Minimum",
       "maximum": "Potential Maximum"
+    },
+    "better": {
+      "title": "Should I sell now?",
+      "cant": "Can't sell now",
+      "no-data": "Need today's price",
+      "yes": "Yes",
+      "prob-yes": "Probably yes",
+      "no": "No",
+      "prob-no": "Probably no",
+      "details": "Probability of better price is"
     }
   },
   "textbox": {


### PR DESCRIPTION
"To sell or not to sell" That is the question myself (and probably most users using the tool) have each day. You need to take a decision: sell now and lose opportunity if the price increases in the next days, or wait for that better price that may not come.

To be precise, the question can be better asked as "What is the probability that I'll have a same or higher price at least once in the following days/periods?". And that probability can be calculated with the chart information and today's price.
This pull request adds this indicator, with a 'yes/probablyyes/no/probablyno' label as well as the probability used to take the decision (in case the user want to be safe and sell even with a probability of 60%).

Note: I have enabled github pages over my repository in order to easily review the changes live. I'll disable it if the pull request is merged: https://trianguloy.github.io/ac-nh-turnip-prices/

## Probability
Calculating the probability is rather easy. The code+comments should be almost self-explanatory, but here I'll explain it with examples.

First we need to have a base price to compare, and days to check. Althoug the code is able to use any price and any days, the user will probably only be interestes in the result with today's price and the next days. The other input is the list of possible patterns and its ranges, to be precise the table the page shows (except for the first row). Now it is just a matter of calculating the probabilty, however as it is usual on these cases, in order to calculate the probability of 'at least one same-or-better price' (which will require calculate the probability of only one, plus only two, plus only three, etc) it is easier and more precise to calculate the probability of all worse prices, and then take the opposite.

* Multiple patterns: If we have the probability for each pattern, we simply need to add those probabilities averaging by the probability of each pattern: P_total = \sum P_pattern * P_totalPattern. Example: if we had two possible patterns with 50% each, one of them with a probability of a worst price of 20%, and the other of 30%, we will end with a total probability of worst price of 0.5 * 0.2 + 0.5 * 0.3 = 0.25 = 25%. Note that the probabilities of each pattern are already normalized, so we don't need to do any further normalization.
* Each pattern, multiple days: For a given pattern, if we have the probability for each day, we need to multiply those probabilities: P_totalPattern = \prod P_day. Remember that we are calculating the probability of all worst prices, that's why it is as easy as multiplying each day. Example: If we have a pattern with probabilities for each possible day as 20% and 60%, then we will end with a probability of the pattern equals 0.2 * 0.6 = 0,12 = 12%. It may seem low, but remember that this is the probability of all worst patterns. There are four possible outcomes: good+good=(1-0.2) * (1-0.6)=0,32, good+bad=(1-0.2) * 0.6=0,48, bad+good=0.2 * (1-0.6)=0.08 and bad+bad=0.2 * 0.6=0.12. Of those 4 possibilities 3 of them are 'good' 0.32+0,48+0.08=0.88 = 88%
* Each day: For each day, we have a range of probabilities, which is assumed to be equaly probable (if it isn't it can be changed with only one line of code). This range have a max and min values, both included (note that if both are the same the range is only one value, but that's not a problem). Then we simply have three cases: if all the range is below or equal to our base price, all possible prices are worse, so the probability is 1. If all the range is above the base price, all possible prices are better, so the probability is 0. In any other case, the base price lies inside the range, dividing it in two parts, so simply take the percentage of the low part (base-min)/(max-min+1). Note that +1 is because both ends are possible and we are using discrete values: if the range is 10-15 with a base price of 12, the possibility of a worst price is (12-10)/(15-10+1)=2/6, exactly [10,11] vs [12,13,14,15].

Some examples of corner cases are:
- If you are only left with a decresing pattern, the probability will be zero (will never have a better price)
- If you are only left with spike patterns and the spikes still didn't appear, the probability will be 100% (the spike will have that better confirmed price)
- If you fill a future day value with a higer price (for testing) the probability will also be 100% (that price)
- On saturday afternoon the probability will always be zero (a corner case due to the product of no values, which is the base value 1). It is still valid because the following days are equivalent to ranges of [0,0], aka worse.

## Special cases
- When today is sunday, it displays a 'can't sell now' message.
- When today's price is not filled yet, it displays a 'need today's price' message
- When the current data is invalid, it displays '---'

## Pull request details
The pull request consists only of added code, nothing existing is modified. To be precise: the function that calculates the probability, the html to display this information, and the required strings for localization. I tried to follow the same code style, however I found some multiple styles so I just followed the most common one. I'm open to suggestions and changes (and possibly fixes) before merging.